### PR TITLE
PKGBUILD: use non-interactive lha extraction

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: Mijail Rondon Viloria <mijailr>
 # Contributor: Fademind
 # Contributor: pedrogabriel
+# Contributor Strykar
 
 pkgname=wd719x-firmware
 pkgver=1
@@ -17,8 +18,8 @@ noextract=('pciscsi.exe')
 build() {
   cd "${srcdir}"
 
-  lha xi pciscsi.exe pci-scsi.exe
-  lha xi pci-scsi.exe nt/wd7296a.sys
+  lha xiq pciscsi.exe pci-scsi.exe
+  lha xiq pci-scsi.exe nt/wd7296a.sys
 
   dd if=wd7296a.sys of=wd719x-risc.bin bs=1 skip=5760 count=14336 status=none
   dd if=wd7296a.sys of=wd719x-wcs.bin bs=1 skip=20096 count=514 status=none


### PR DESCRIPTION
Arch package installation is non-interactive.
Add the `q` switch to `lha` to suppress these messages:
```
pci-scsi.exe OverWrite ?(Yes/[No]/All/Skip) y
pci-scsi.exe	- Melted   :  oooooooooooooooooooooooooooooooooooooooooo
wd7296a.sys OverWrite ?(Yes/[No]/All/Skip)
wd7296a.sys	- Melted   :  ooooooo
```